### PR TITLE
feat: Refactor CLI to read from stdin and output JSON

### DIFF
--- a/yaml_reference/cli.py
+++ b/yaml_reference/cli.py
@@ -1,68 +1,34 @@
+import json
 import sys
-from pathlib import Path
-from typing import Optional
-
-from ruamel.yaml import YAML as YAMLRuamel
 
 from yaml_reference import YAMLReference
 
 
-def compile_main(
-    input_file: Optional[str] = None,
-    output_file: Optional[str] = None,
-):
+def compile_main():
     """
-    Compile a YAML file containing !reference tags into a new YAML file with resolved references. The resulting output
-    YAML document will be "safely" formatted:
+    Compile a YAML file from stdin containing !reference tags into a JSON file with resolved references. The resulting
+    output JSON document (dumped to stdout) will be "safely" formatted:
 
-        1. Aliases / anchors are resolved,
-        2. All data is block-formatted, and
-        3. Keys of mappings are sorted.
+        1. Keys in mappings are sorted, and
+        2. Indentation is a consistent 2 spaces.
 
     This is intended to accurately portray the contents of the YAML file as loaded into memory, demonstrating the
     resolution of references in deterministic way.
-
-    Args:
-        input_file (str): The path to the input YAML file. If not provided, the function will read from standard input.
-        output_file (str): The path to the output YAML file. If not provided, the function will write to standard output.
     """
     yaml = YAMLReference(typ="safe")
 
-    if input_file is None:
-        input_handle = sys.stdin
-    else:
-        input_handle = Path(input_file).open("r")
+    data = yaml.load(sys.stdin)
 
-    if output_file is None:
-        output_handle = sys.stdout
-    else:
-        output_handle = Path(output_file).open("w")
-
-    data = yaml.load(input_handle)
-    writer_yaml = YAMLRuamel(typ="safe")
-    writer_yaml.representer.ignore_aliases = lambda *_: True
-    writer_yaml.representer.default_flow_style = False
-
-    writer_yaml.dump(data, output_handle)
+    json.dump(data, sys.stdout, sort_keys=True, indent=2)
 
 
 def compile_cli():
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Compile a YAML file containing !reference tags into a new YAML file with resolved references."
-    )
-    parser.add_argument(
-        "-i",
-        "--input",
-        type=str,
-        help="Path to the input YAML file. If not provided, reads from stdin.",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        help="Path to the output YAML file. If not provided, writes to stdout.",
-    )
-    args = parser.parse_args()
-    compile_main(args.input, args.output)
+    argparse.ArgumentParser(
+        description=(
+            "Compile a YAML file containing !reference tags into a new YAML file with resolved references. "
+            "Expects a YAML file to be provided in stdin. Outputs JSON content to stdout."
+        )
+    ).parse_args()
+    compile_main()


### PR DESCRIPTION
# CLI I/O Mode Change

## Overview
Refactored the CLI tool to output JSON instead of YAML for better interoperability and deterministic formatting. For consistency, the tool now reads exclusively from stdin and writes to stdout.

## Changes Made

### 1. **Output Format Changed**
- **Before**: Outputs YAML with ruamel.yaml formatting
- **After**: Outputs JSON with sorted keys and 2-space indentation

### 2. **Simplified Interface**
- Removed file I/O arguments (`-i/--input`, `-o/--output`)
- Now reads exclusively from stdin and writes to stdout
- Eliminated dependency on `ruamel.yaml`

## Benefits
1. **Deterministic Output**: JSON provides consistent key ordering
2. **Interoperability**: JSON is widely supported across programming languages
3. **Simplified Usage**: Single-purpose tool (stdin -> stdout)
4. **Reduced Dependencies**: Removes ruamel.yaml dependency

## Usage Example
```bash
# Before
yref-compile -i input.yaml -o output.yaml

# After
cat input.yaml | yref-compile > output.json
```

## Testing
The core functionality remains unchanged - only the output format differs. The `!reference` tag resolution logic in `YAMLReference` class is unaffected.
